### PR TITLE
Update processing logic to use event textEditor instead of window activeTextEditor

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,7 @@ class LineTrimmer {
     }
 
     onChangeSelection(e: vscode.TextEditorSelectionChangeEvent) {
-        const editor = vscode.window.activeTextEditor;
+        const editor = e.textEditor;
         const doc = editor.document;
         const lines = new Set<number>(e.selections.map(sel => sel.active.line));
         const previousLines = this._lines.get(doc);


### PR DESCRIPTION
Fixes a bug in the extension where sometimes the window.activeTextEditor is not the same as the onChangeSelection event textEditor. The bug causes the removal of end-of-line spaces when the line is still active.